### PR TITLE
Extensional tensor

### DIFF
--- a/MLIR/Dialects/ArithSemantics.lean
+++ b/MLIR/Dialects/ArithSemantics.lean
@@ -367,14 +367,9 @@ theorem equivalent (n m: FinInt 32):
         run, StateT.run,
         denoteOp, bind, List.mapM, StateT.bind,
         List.mapM.loop, Except.bind, TopM.get, StateT.get, pure, Except.pure, StateT.pure, OpM.toTopM, TopM.set, StateT.set, MLIRType.eval];
-   constructor;
    unfold cast;
    unfold MLIRType.eval;
-   simp;
-   rewrite [FinInt.add_comm'];
-   rfl;
-   rewrite [FinInt.add_comm'];
-   rfl;
+   simp[FinInt.add_comm'];
 end th1
 
 /-

--- a/MLIR/Dialects/LinalgSemantics.lean
+++ b/MLIR/Dialects/LinalgSemantics.lean
@@ -199,21 +199,19 @@ theorem equiv (t: Tensor1D) r rSpec:
    run ⟦RHS r⟧ (SSAEnv.One [ ("t", ⟨.tensor1d, t⟩) ]) := by {
       intros valid_r;
       simp[LHS, RHS];
-      simp_all[denoteRegion, run, StateT.run, denoteTypedArgs, pure, StateT.pure, Except.pure,
+      simp_all[denoteRegion, run, StateT.run, List.map, denoteTypedArgs, pure, StateT.pure, Except.pure,
             StateT.run, Except.ok, bind, Except.bind, denoteOps, denoteOps
             , StateT.bind, denoteOp, List.mapM, List.mapM.loop, TopM.get,
             StateT.get, OpM.toTopM, TopM.raiseUB, liftM, TopM.set,
-            StateT.set, cast, OpM.denoteRegion, OpM.toTopM, denoteRegion];
+            StateT.set, cast, OpM.denoteRegions, TopM.mapDenoteRegion,
+             OpM.toTopM, denoteRegion];
       save;
-      simp [OpM.denoteRegion];
       simp [Semantics.semantics_op];
-      sorry; sorry
-      /-
-      -- simp[linalg_semantics_op];
-      sorry
-      -- this is blocked on:
-      --  + 'failed to generate equality theorems for match expression'
-      -/
+      rewrite [linalg_semantics_generic1d];
+      simp;
+      sorry;
+      sorry;
+      sorry;
     }
 end ExtractSliceGenericCommute1D
 

--- a/MLIR/Dialects/ScfSemantics.lean
+++ b/MLIR/Dialects/ScfSemantics.lean
@@ -99,7 +99,7 @@ theorem equivalent (b: Bool):
     run ⟦LHS r₁ r₂⟧ (INPUT b) =
     run ⟦if b then r₁ else r₂⟧ (INPUT b) := by
   simp [LHS, INPUT, denoteRegion,  denoteOps, denoteTypedArgs]
-  simp [denoteOp, List.map, List.zip, List.zipWith, List.mapM, List.mapM.loop, pure, 
+  simp [denoteOp, List.map, List.zip, List.zipWith, List.mapM, List.mapM.loop, pure,
         StateT.pure, Except.pure, Except.ok, OpM.toTopM, TopM.get, SSAEnv.get, StateT.get,
         StateT.bind]
   sorry -- proof broken when upgrading Lean.

--- a/MLIR/Semantics/Semantics.lean
+++ b/MLIR/Semantics/Semantics.lean
@@ -64,13 +64,21 @@ inductive IOp (δ: Dialect α σ ε) := | mk
 -- TODO: make `TopM.set` fail if we write to an already defined value.
 -- This enforces the SSA property.
 -- TODO: make `runRegion` clear the SSA state, forcing the region
--- to be isolated from above. 
-abbrev TopM (Δ: Dialect α σ ε) (R: Type _) := StateT (SSAEnv Δ) (Except String) R
-def TopM.run (t: TopM Δ R) (env: SSAEnv Δ): Except String (R × SSAEnv Δ) :=
+-- to be isolated from above.
+abbrev TopM (Δ: Dialect α σ ε) (R: Type _) := StateT (SSAEnv Δ) (Except (String × (SSAEnv Δ))) R
+def TopM.run (t: TopM Δ R) (env: SSAEnv Δ): Except (String × (SSAEnv Δ)) (R × SSAEnv Δ) :=
   StateT.run t env
 
-def TopM.raiseUB {Δ: Dialect α σ ε} (message: String): TopM Δ R :=
-  Except.error message
+def TopM.scoped (t: TopM Δ R): TopM Δ R := do
+  let state ← get -- save scope
+  let res ← t -- run computation
+  set state -- restore scope
+  return res -- return result
+
+
+def TopM.raiseUB {Δ: Dialect α σ ε} (message: String): TopM Δ R := do
+  let state ← get
+  Except.error (message, state)
 
 def TopM.get {Δ: Dialect α σ ε} (τ: MLIRType Δ) (name: SSAVal): TopM Δ τ.eval := do
   let s ← StateT.get
@@ -80,7 +88,7 @@ def TopM.get {Δ: Dialect α σ ε} (τ: MLIRType Δ) (name: SSAVal): TopM Δ τ
 
 def TopM.set {Δ: Dialect α σ ε} (τ: MLIRType Δ) (name: SSAVal) (v: τ.eval): TopM Δ Unit := do
   let s ← StateT.get
-  match SSAEnv.get name τ s with 
+  match SSAEnv.get name τ s with
   | .some v' => if v == v' then pure () else TopM.raiseUB "setting to SSA value twice!"
   | .none => StateT.set (SSAEnv.set name τ v s)
 
@@ -129,22 +137,22 @@ def denoteTypedArgs (args: TypedArgs Δ) (names: List SSAVal): TopM Δ Unit :=
         denoteTypedArgs args names
 
 -- Denote a region with an abstract `OpM.RunRegion`
-def denoteRegionOpM {Δ: Dialect α σ ε}
+def OpM.denoteRegion {Δ: Dialect α σ ε}
   (_r: Region Δ)
   (ix: Nat): TypedArgs Δ → OpM Δ (TypedArgs Δ) :=
    fun args => OpM.RunRegion ix args (fun retvals => OpM.Ret retvals)
 
 -- Denote the list of regions with an abstract `OpM.runRegion`
-def denoteRegionsOpM {Δ: Dialect α σ ε}
+def OpM.denoteRegions {Δ: Dialect α σ ε}
   (regions: List (Region Δ))
   (ix: Nat): List (TypedArgs Δ → OpM Δ (TypedArgs Δ)) :=
  match regions with
  | [] => []
- | r :: rs => (denoteRegionOpM r ix) :: denoteRegionsOpM rs (ix + 1)
+ | r :: rs => (OpM.denoteRegion r ix) :: OpM.denoteRegions rs (ix + 1)
 
 -- Denote a region by using its denotation function from the list
 -- of regions. TODO: refactor to use Option
-def denoteRegionByIx
+def TopM.denoteRegionsByIx
   (rs0: List (TypedArgs Δ → TopM Δ (TypedArgs Δ)))
  (ix: Nat) (args: TypedArgs Δ): TopM Δ (TypedArgs Δ) :=
   match rs0 with
@@ -152,7 +160,7 @@ def denoteRegionByIx
   | r:: rs' =>
     match ix with
     | 0 => r args
-    | ix' + 1 => denoteRegionByIx rs' ix' args
+    | ix' + 1 => TopM.denoteRegionsByIx rs' ix' args
 
 -- Morphism from OpM to topM
 def OpM.toTopM (rs0: List (TypedArgs Δ → TopM Δ (TypedArgs Δ))):
@@ -161,60 +169,47 @@ def OpM.toTopM (rs0: List (TypedArgs Δ → TopM Δ (TypedArgs Δ))):
 | OpM.Ret r => pure r
 | OpM.Error s => TopM.raiseUB s
 | OpM.RunRegion ix args k => do
-       let ret <- denoteRegionByIx rs0 ix args
+       let ret <- TopM.denoteRegionsByIx rs0 ix args
        OpM.toTopM rs0 (k ret)
-
 mutual
 variable (Δ: Dialect α' σ' ε') [S: Semantics Δ]
 
 -- unfolded version of List.map denoteRegion.
 -- This allows the termination checker to view the termination.
-def mapDenoteRegion:
+def TopM.mapDenoteRegion:
   List (Region Δ) →
   List (TypedArgs Δ → TopM Δ (TypedArgs Δ))
 | [] => []
-| r :: rs => (denoteRegion r) :: mapDenoteRegion rs
+| r :: rs => (TopM.scoped ∘ denoteRegion r) :: TopM.mapDenoteRegion rs
 
 -- Convert a region to its denotation to establish finiteness.
 -- Then use this finiteness condition to evaluate region semantics.
 -- Use the morphism from OpM to TopM.
-def denoteOp (op: Op Δ) (terminator: Bool):
+def denoteOp (op: Op Δ):
     TopM Δ (TypedArgs Δ) :=
   match op with
   | .mk name res0 args0 regions0 attrs => do
-      let regionSemantics := mapDenoteRegion regions0
       let resTy := res0.map Prod.snd
       let args ← args0.mapM (fun (name, τ) => do
         pure ⟨τ, ← TopM.get τ name⟩)
       -- Built the interpreted operation
-      let iop : IOp Δ := IOp.mk name resTy args (denoteRegionsOpM regions0 0) attrs
+      let iop : IOp Δ := IOp.mk name resTy args (OpM.denoteRegions regions0 0) attrs
       -- Use the dialect-provided semantics, and substitute regions
-      let ret ← OpM.toTopM regionSemantics (S.semantics_op iop)
-      if not terminator then
-        match (res0, ret) with
-        | ([res], [⟨τ, v⟩]) =>
-            TopM.set τ res.fst v
-            return ret
-        | ([], []) =>
-            return ret
-        | _ =>
-          TopM.raiseUB s!"more than one result or unmatched result/expected pair: {op}"
-      else  -- TODO: refactor this code to be easier to read!
-        match (res0, ret) with
-        | ([res], [⟨τ, v⟩]) =>
-            TopM.set τ res.fst v
-            return ret
-        | _ => return ret
-
-
+      let ret ← OpM.toTopM (TopM.mapDenoteRegion regions0) (S.semantics_op iop)
+      match res0 with
+      | [] => pure ()
+      | [res] => match ret with
+          | [⟨τ, v⟩] => TopM.set τ res.fst v
+          | _ => TopM.raiseUB s!"denoteOp: expected 1 return value, got '{ret}'"
+      | _ => TopM.raiseUB s!"denoteOp: expected 0 or 1 results, got '{res0}'"
+      return ret
   -- denote a sequence of ops
-
 def denoteOps (stmts: List (Op Δ)): TopM Δ (TypedArgs Δ) :=
    match stmts with
    | [] => return  []
-   | [stmt] => denoteOp stmt (terminator := true)
+   | [stmt] => denoteOp stmt
    | (stmt :: stmts') => do
-        let _ ← denoteOp stmt (terminator := false)
+        let _ ← denoteOp stmt
         denoteOps stmts'
 
 def denoteRegion (rgn: Region Δ) (args: TypedArgs Δ):
@@ -522,7 +517,7 @@ def run! {Δ: Dialect α' σ' ε'}  {R} [Inhabited R]
 
 def run {Δ: Dialect α' σ' ε'} {R}
     (t: TopM  Δ R) (env: SSAEnv Δ):
-    Except String (R × SSAEnv Δ) :=
+    Except (String × SSAEnv Δ) (R × SSAEnv Δ) :=
   StateT.run t env
 
 -- The property for two programs to execute with no error and satisfy a
@@ -549,8 +544,7 @@ class Denote (δ: Dialect α σ ε) [S: Semantics δ]
 notation "⟦ " t " ⟧" => Denote.denote t
 
 instance DenoteOp (δ: Dialect α σ ε) [Semantics δ]: Denote δ Op where
-  denote op := denoteOp δ op (terminator := true)
-
+  denote op := denoteOp δ op
 -- This only works for single-BB regions with no arguments
 instance DenoteRegion (δ: Dialect α σ ε) [Semantics δ]: Denote δ Region where
   denote r := denoteRegion δ r []
@@ -558,6 +552,6 @@ instance DenoteRegion (δ: Dialect α σ ε) [Semantics δ]: Denote δ Region wh
 -- Not for regions because we need to specify the fuel
 
 @[simp] theorem Denote.denoteOp [Semantics δ]:
-  Denote.denote (self := DenoteOp δ) op = denoteOp δ op (terminator := true) := rfl
+  Denote.denote (self := DenoteOp δ) op = denoteOp δ op := rfl
 @[simp] theorem Denote.denoteRegion [Semantics δ]:
   Denote.denote (self := DenoteRegion δ) r = denoteRegion δ r [] := rfl

--- a/MLIR/Semantics/Semantics.lean
+++ b/MLIR/Semantics/Semantics.lean
@@ -61,15 +61,13 @@ inductive IOp (δ: Dialect α σ ε) := | mk
 
 
 -- The monad in which these computations are run
--- TODO: make `TopM.set` fail if we write to an already defined value.
--- This enforces the SSA property.
--- TODO: make `runRegion` clear the SSA state, forcing the region
--- to be isolated from above.
 abbrev TopM (Δ: Dialect α σ ε) (R: Type _) := StateT (SSAEnv Δ) (Except (String × (SSAEnv Δ))) R
 def TopM.run (t: TopM Δ R) (env: SSAEnv Δ): Except (String × (SSAEnv Δ)) (R × SSAEnv Δ) :=
   StateT.run t env
 
 def TopM.scoped (t: TopM Δ R): TopM Δ R := do
+  -- TODO: convert this to using the `SSAEnv`'s ability to a stack of `SSAScope`,
+  -- instead of approximating it with overwriting the `SSAEnv` temporarily.
   let state ← get -- save scope
   let res ← t -- run computation
   set state -- restore scope
@@ -103,7 +101,6 @@ theorem set_interference_ub
 theorem set_commutes_set:
 theorem get_commutes_get
 theorem get_commutes_noninterfering_set
-theorem get_set
 -/
 
 class Semantics (Δ: Dialect α σ ε)  where

--- a/MLIR/Util/KDTensor.lean
+++ b/MLIR/Util/KDTensor.lean
@@ -82,12 +82,6 @@ instance : Inhabited Tensor1D where
 instance : ToString Tensor1D where
   toString t := "Tensor1D"
 
-
-structure Point2D where 
-  x: Nat
-  y: Nat 
-
-
 structure TensorIndex2D (size0: Nat) (size1: Nat): Type where 
   ix0: Nat
   ix1: Nat 
@@ -126,16 +120,6 @@ def TensorIndex2D.enlarge {size0 size0' size1 size1': Nat}
         apply Nat.lt_of_lt_of_le H INC1;
     }
   }
--- extract subview: (n, m) of (N, M)
--- subview: TensorSubview2D n m
--- tensor: Tensor N M
--- hypothesis: (n <= N) (m <= M)
--- produce: Tensor n m
---   ix => TensorIndex2D n m
---     ix.size0 < n
---     ix.size1 < m
-
-
 def TensorIndex2D.transpose
   (ix: TensorIndex2D size0 size1): TensorIndex2D size1 size0 := {
     ix0 := ix.ix1
@@ -144,7 +128,7 @@ def TensorIndex2D.transpose
     IX1 := ix.IX0
   }
 
-lemma Nat.lt_mul_cancel_left (a b x: Nat) (H: a < b): a * x < b * x := by sorry;
+lemma Nat.lt_mul_cancel_left (a b x: Nat) (H: a < b): a * x < b * x := by sorry_arith;
 
 def TensorIndex2D.stride (ix: TensorIndex2D size0 size1) (stride0: Nat) (stride1: Nat):
   TensorIndex2D (size0*stride0) (size1*stride1) := {
@@ -569,11 +553,9 @@ def TensorFlatIndex.merge
      sorry
   })
 
-
-
-
-
-
+/-
+Fully generic ND index. Currently unused.
+-/
 inductive TensorIndex': List Nat -> Type :=
 |  Empty: TensorIndex' []
 |  Dim (bound0: Nat)

--- a/MLIR/Util/KDTensor.lean
+++ b/MLIR/Util/KDTensor.lean
@@ -128,19 +128,19 @@ def TensorIndex2D.transpose
     IX1 := ix.IX0
   }
 
-lemma Nat.lt_mul_cancel_left (a b x: Nat) (H: a < b): a * x < b * x := by sorry_arith;
+lemma Nat.lt_mul_cancel_left (a b x: Nat) (H: a < b) (XNEQ0: 0 < x): a * x < b * x := by sorry_arith;
 
-def TensorIndex2D.stride (ix: TensorIndex2D size0 size1) (stride0: Nat) (stride1: Nat):
-  TensorIndex2D (size0*stride0) (size1*stride1) := {
+def TensorIndex2D.stride (ix: TensorIndex2D size0 size1) (stride0: Nat) (STRIDE0: 0 < stride0)
+  (stride1: Nat) (STRIDE1: 0 < stride1): TensorIndex2D (size0*stride0) (size1*stride1) := {
   ix0 := ix.ix0 * stride0
   ix1 := ix.ix1 * stride1
   IX0 := by { 
       have H: ix.ix0 < size0 := ix.IX0;
-      simp [H, Nat.lt_mul_cancel_left]; 
+      apply Nat.lt_mul_cancel_left <;> assumption
      }
   IX1 := by { 
       have H: ix.ix1 < size1 := ix.IX1;
-      simp [H, Nat.lt_mul_cancel_left]; 
+      apply Nat.lt_mul_cancel_left <;> assumption
   }
 }
 /-
@@ -220,9 +220,9 @@ def Tensor2D.transpose (t: Tensor2D): Tensor2D :=
 
 -- Stride index into a tensor, scaling the indexing by `stride0, stride1`. 
 def Tensor2D.stride (t: Tensor2D) (stride0 stride1: Nat)
-  (STRIDE0: stride0 > 0) (STRIDE1: stride1 > 0): Tensor2D :=
+  (STRIDE0: 0 < stride0) (STRIDE1:  0 < stride1): Tensor2D :=
   Tensor2D.mk (t.size0 / stride0) (t.size1 / stride1) 
-    (fun ix => t.data <| (ix.stride stride0 stride1).enlarge
+    (fun ix => t.data <| (ix.stride stride0 STRIDE0 stride1 STRIDE1).enlarge
     (by { rewrite[<- Nat.le_div_iff_mul_le]; simp_arith; apply STRIDE0; })
     (by { rewrite[<- Nat.le_div_iff_mul_le]; simp_arith; apply STRIDE1; }))
 


### PR DESCRIPTION
I develop a small theory of 2D tensors, in particular, for things like `transpose` and `insert/extractslice2D`. I argue that having a representation of the form `data: TensorIndex2D size0 size1 -> Int` makes life way easier :smile: 

@lephe I am curious how you would implement `transpose`, `insert/extractslice2d` in a way that is convenient. I recall that we did indeed have a `transpose` in Toy, which required us to reason about the flattened index. 

Even if we use the memory representation as `data2d :: List (List Int))`, the theorem that `transpose . transpose = id` would be finicky, would it not? 

Compare this to the one using the functional based representation `data: TensorIndex2D size0 size1 -> Int` , where the transpose is much more straightforward. 