### PR TITLE
Encode Programs as Expression trees

### DIFF
--- a/MLIR/Semantics/Semantics.lean
+++ b/MLIR/Semantics/Semantics.lean
@@ -51,17 +51,23 @@ instance : Monad (OpM Δ) where
 
 instance : LawfulMonad (OpM Δ) := sorry
 
+/-
+Denotation of the _syntax_ of the op.
+-/
 -- Interpreted operation, like MLIR.AST.Op, but with less syntax
 inductive IOp (δ: Dialect α σ ε) := | mk
   (name:    String) -- TODO: name should come from an Enum in δ.
   (resTy:   List (MLIRType δ))
   (args:    TypedArgs δ)
-  (regions: List (TypedArgs δ → OpM δ (TypedArgs δ))) -- TODO: surely, I can build the denotation of a region and pass it along to you?
+  -- | Since this simply constructs the corresponding
+  -- `RunRegion` call, consider removing this.
+  (regions: List (TypedArgs δ → OpM δ (TypedArgs δ)))
   (attrs:   AttrDict δ)
 
 
 -- The monad in which these computations are run
-abbrev TopM (Δ: Dialect α σ ε) (R: Type _) := StateT (SSAEnv Δ) (Except String) R
+abbrev TopM (Δ: Dialect α σ ε) (R: Type _) :=
+  StateT (SSAEnv Δ) (Except String) R
 def TopM.run (t: TopM Δ R) (env: SSAEnv Δ): Except String (R × SSAEnv Δ) :=
   StateT.run t env
 


### PR DESCRIPTION
If we choose to forego SSA, then we can simply represent programs via expression trees.
We can have layers to our framework, of the form `SSA -> Expression Tree -> OpM/TopM`. 
Thus, proofs about naming are handled at the SSA level, while the semantics will be entirely pure. 

Note that we incur the cost a `StateT SSAEnv` since we need to load/store names.
If we remove names entirely, represent sequences of operations as expression trees, and names of entry arguments of a region via substitution, we can effectively get rid of names. 

- Think about converting our representation to a tree, and convert function application into substitution.
- This substitution makes our semantics pure.
- This means that properties such as "running a region is pure" is available for free, since substitution is a pure operation that does not need state.
